### PR TITLE
Add charter definitions

### DIFF
--- a/draft-fainchtein-diem-use-cases.md
+++ b/draft-fainchtein-diem-use-cases.md
@@ -126,26 +126,28 @@ These definitions have been reproduced in section Conventions and Definitions.
 
 {::boilerplate bcp14-tagged}
 
-The definitions for terms "(digital) emblem," "bearer," and "validation" are reproduced from the current charter as of
-this writing.
+The definitions for terms "(digital) emblem," "bearer," and "validation" are reproduced from the charter {{CHARTER}} as of this writing.
 
 
-Emblems such as the Red Cross, Red Crescent, Red Crystal, and Blue Shield can be symbols of protection governed by International Humanitarian Law (IHL).
-Emblems can also be identified by other laws, agreements, or standards.
-There is a need to present emblems through digital communication channels.
-Emblems presented in such ways are called digital emblems.
-Digital emblems extend the range of identifying marks from the physical (visual and tactile) to the digital realm.
+(Digital) Emblem:
+: Emblems such as the Red Cross, Red Crescent, Red Crystal, and Blue Shield can be symbols of protection governed by International Humanitarian Law (IHL).
+  Emblems can also be identified by other laws, agreements, or standards.
+  There is a need to present emblems through digital communication channels.
+  Emblems presented in such ways are called digital emblems.
+  Digital emblems extend the range of identifying marks from the physical (visual and tactile) to the digital realm.
 
+Bearer:
+: "To bear an emblem" means to present and be identified by a digital emblem.
+  The entity that bears the emblem is the bearer or emblem holder.
+  This is often a separate entity from the creator or original designer of the emblem.
 
-"To bear an emblem" means to present and be identified by a digital emblem.
-The entity that bears the emblem is the bearer or emblem holder.
-This is often a separate entity from the creator or original designer of the emblem.
-"To validate an emblem" means to confirm the authenticity or legitimacy of a particular symbol or design,
+Validation:
+: "To validate an emblem" means to confirm the authenticity or legitimacy of a particular symbol or design,
 often by checking its details against a known standard or reference point.
-Validation may include ensuring that the bearer has not forged, stolen, or tampered with an emblem.
-Emblems may be observed by validators without the knowledge of the bearer presenting the emblem, or may be presented to a specific validator upon request.
-Cryptographic verification may or may not be used based on the in-place security mechanisms of the communication channel bearing the emblem.
-Which attributes an emblem contains, and how a digital emblem is secured and presented impacts how a validator interprets and trusts the assertions made within the emblem.
+  Validation may include ensuring that the bearer has not forged, stolen, or tampered with an emblem.
+  Emblems may be observed by validators without the knowledge of the bearer presenting the emblem, or may be presented to a specific validator upon request.
+  Cryptographic verification may or may not be used based on the in-place security mechanisms of the communication channel bearing the emblem.
+  Which attributes an emblem contains, and how a digital emblem is secured and presented impacts how a validator interprets and trusts the assertions made within the emblem.
 
 # Requirements
 


### PR DESCRIPTION
Explicitly adds the definitions for terms "(digital) emblem," bearer" and "validations" from the current charter.  