### PR TITLE
Expand requirements to flexibly account for less-understood use cases

### DIFF
--- a/draft-ietf-diem-requirements.md
+++ b/draft-ietf-diem-requirements.md
@@ -167,7 +167,7 @@ The DIEM architecture will allow validators to discover and validate digital emb
 
 ### Digital Emblem Format
 
-Digital emblems MUST identify the marked asset and their kind of digital emblem. Beyond that, digital emblems MAY include other data, for example, an issuer or a validity window. To accommodate use cases requiring extensible data, a digital emblem architecture SHOULD introduced minimal overhead size except for fields required to fulfil other requirements in this document. 
+Digital emblems MUST identify the marked asset and their kind of digital emblem. Beyond that, digital emblems MAY include other data, for example, an issuer or a validity window. To accommodate use cases requiring extensible data, a digital emblem architecture SHOULD introduced minimal overhead size except for fields required to fulfil other requirements in this document.
 
 As of writing, the DIEM charter requires that digital emblems MUST explicitly identify the marked asset by a Fully Qualified Domain Name (FQDN).
 

--- a/draft-ietf-diem-requirements.md
+++ b/draft-ietf-diem-requirements.md
@@ -166,6 +166,7 @@ The DIEM architecture will allow validators to discover and validate digital emb
 ## Digital Emblem Requirements
 
 ### Digital Emblem Format
+
 Digital emblems MUST identify the marked asset and their kind of digital emblem. Beyond that, digital emblems MAY include other data, for example, an issuer or a validity window. To accommodate use cases requiring extensible data, a digital emblem architecture SHOULD introduced minimal overhead size except for fields required to fulfil other requirements in this document. 
 
 As of writing, the DIEM charter requires that digital emblems MUST explicitly identify the marked asset by a Fully Qualified Domain Name (FQDN).

--- a/draft-ietf-diem-requirements.md
+++ b/draft-ietf-diem-requirements.md
@@ -166,7 +166,9 @@ The DIEM architecture will allow validators to discover and validate digital emb
 ## Digital Emblem Requirements
 
 ### Digital Emblem Format
-Digital emblems MUST identify the marked asset and their kind of digital emblem. Beyond that, digital emblems MAY include other data, for example, an issuer or a validity window. As of writing, the DIEM charter requires that digital emblems MUST explicitly identify the marked asset by a Fully Qualified Domain Name (FQDN).
+Digital emblems MUST identify the marked asset and their kind of digital emblem. Beyond that, digital emblems MAY include other data, for example, an issuer or a validity window. To accommodate use cases requiring extensible data, a digital emblem architecture SHOULD introduced minimal overhead size except for fields required to fulfil other requirements in this document. 
+
+As of writing, the DIEM charter requires that digital emblems MUST explicitly identify the marked asset by a Fully Qualified Domain Name (FQDN).
 
 ### Emblem Semantics
 Individual use cases MUST specify the semantics of the emblem. It must be clearly stated how discovery and validation of a digital emblem should inform validator behavior.
@@ -197,15 +199,15 @@ This threat model must detail which parties can detect emblem discovery and vali
 
 ### Validation {#validation}
 
-Digital emblems MAY require validation. Validation MUST support verification of all the emblem's data and its context.
-In particular, validation MUST ensure that the emblem was issued for the respective asset.
+Digital emblems MAY require validation. The digital emblem architecture MUST allow individual standards to support verification of all the digital emblem's data or a defined subset without restriction. This ensures digital emblems can support static or dynamic data without having to account for the pain of frequent re-signing of dynamic data if its validation is not required by a given digital emblem type.
+In particular, when validation is defined, it MUST ensure that the emblem was issued for the respective asset.
 Some use cases MAY use unverified digital emblems.
 
 ### Authorization {#authorization}
 
-Digital emblems MAY require authorization by third-parties.
+Digital emblems MAY require authorization by third-parties. When they do, they MUST define a trust model that describes how validators can discover authorities and how the system selects authorities. The generalized digital emblem architecture MUST NOT assume that Internet access is available or required so that individual digital emblems standards can choose to take a dependency on Internet access or not. For example, a given digital emblem MAY use PKI or the DNS as a root of trust if they want, but the generalized digital emblem architecture cannot mandate this or other options and MUST make this a point of extensibility.
+
 Any authorization mechanism MUST account for the possibility of compromise of cryptographic key material, for example, by specifying revocation mechanisms or using short-lived credentials.
-Individual profiles MUST standardize a trust model that describes how validators can discover authorities and how the system selects authorities.
 
 ## Other Requirements
 

--- a/draft-ietf-diem-requirements.md
+++ b/draft-ietf-diem-requirements.md
@@ -167,7 +167,9 @@ The DIEM architecture will allow validators to discover and validate digital emb
 
 ### Digital Emblem Format
 
-Digital emblems MUST identify the marked asset and their kind of digital emblem. Beyond that, digital emblems MAY include other data, for example, an issuer or a validity window. To accommodate use cases requiring extensible data, a digital emblem architecture SHOULD introduced minimal overhead size except for fields required to fulfil other requirements in this document.
+Digital emblems MUST identify the marked asset and their kind of digital emblem.
+Beyond that, digital emblems MAY include other data, for example, an issuer or a validity window.
+To accommodate use cases requiring extensible data, a digital emblem architecture SHOULD introduced minimal overhead size except for fields required to fulfil other requirements in this document.
 
 As of writing, the DIEM charter requires that digital emblems MUST explicitly identify the marked asset by a Fully Qualified Domain Name (FQDN).
 

--- a/draft-ietf-diem-requirements.md
+++ b/draft-ietf-diem-requirements.md
@@ -169,7 +169,7 @@ The DIEM architecture will allow validators to discover and validate digital emb
 
 Digital emblems MUST identify the marked asset and their kind of digital emblem.
 Beyond that, digital emblems MAY include other data, for example, an issuer or a validity window.
-To accommodate use cases requiring extensible data, a digital emblem architecture SHOULD introduced minimal overhead size except for fields required to fulfil other requirements in this document.
+To accommodate use cases requiring extensible data, a digital emblem architecture SHOULD introduce minimal overhead size except for fields required to fulfil other requirements in this document.
 
 As of writing, the DIEM charter requires that digital emblems MUST explicitly identify the marked asset by a Fully Qualified Domain Name (FQDN).
 


### PR DESCRIPTION
This requirement expansion resulted from brainstorming with Rohan about the use cases that aren't well represented in WG participation but have been brought up as potential future uses of Digital Emblems.

I believe with such an expansion, the continued expansion of use cases becomes unnecessary given this seems to account for the things required by the beyond-initial-scope cases without having to go through the controversy of debating appropriateness of each of these individually. The intention is to ensure the requirements on the architecture document specifically permit the flexibility needed for Deliverable 3 documents (specific digital emblem standards) to do whatever they need to without having to support arbitrary requirements of one another.

@ohmantics @amankin  I especially want to hear your take as people passionately exploring other use cases.

FYI @rohanmahy 