### PR TITLE
Response requirements

### DIFF
--- a/draft-ietf-diem-requirements.md
+++ b/draft-ietf-diem-requirements.md
@@ -198,6 +198,19 @@ Individual use cases MUST specify the semantics of the emblem. It must be clearl
 
 Digital emblems MUST specify how validators can check for the presence of a digital emblem. That is, given an asset a validator must be able to determine whether it has an associated emblem. For example, verifying whether a FQDN has an emblem associated with it could be realized by fetching digital emblem-associated records for said FQDN.
 
+
+### Query Response {#response-reqs}
+
+Specifications for each use case MUST each determine how responses to queries for Digital Emblems of their specified type are handled.
+Specifically, they must determine the responsiveness and consistency requirements for emblems of their given type and provide explanations of how the chosen requirements apply and rationales for their selection. 
+
+For responsiveness, an instance of a specific type of digital emblem can either be required to respond to all queries for it (Assured Response), or allowed to selectively respond to a specific subset of incoming queries (Selective Response).
+
+For consistency of response  specifications for a given type of digital emblem must denote whether consistent content is required for all responses provided (Consistent Content) or whether the contents of a response may vary based on specific requester attributes (Selective Content).
+ 
+While some use cases may be able to allow selective response and/or selective content, assured response and consistent
+content are  prerequisites for proof of presence.
+
 ### Removable {#removable}
 
 Digital emblems MAY require to be removable in that checking for the presence of an asset's emblems results in no emblem.

--- a/draft-ietf-diem-requirements.md
+++ b/draft-ietf-diem-requirements.md
@@ -202,12 +202,12 @@ Digital emblems MUST specify how validators can check for the presence of a digi
 ### Query Response {#response-reqs}
 
 Specifications for each use case MUST each determine how responses to queries for Digital Emblems of their specified type are handled.
-Specifically, they must determine the responsiveness and consistency requirements for emblems of their given type and provide explanations of how the chosen requirements apply and rationales for their selection. 
+Specifically, they must determine the responsiveness and consistency requirements for emblems of their given type and provide explanations of how the chosen requirements apply and rationales for their selection.
 
 For responsiveness, an instance of a specific type of digital emblem can either be required to respond to all queries for it (Assured Response), or allowed to selectively respond to a specific subset of incoming queries (Selective Response).
 
 For consistency of response  specifications for a given type of digital emblem must denote whether consistent content is required for all responses provided (Consistent Content) or whether the contents of a response may vary based on specific requester attributes (Selective Content).
- 
+
 While some use cases may be able to allow selective response and/or selective content, assured response and consistent
 content are  prerequisites for proof of presence.
 

--- a/draft-ietf-diem-requirements.md
+++ b/draft-ietf-diem-requirements.md
@@ -201,12 +201,20 @@ Digital emblems MUST specify how validators can check for the presence of a digi
 
 ### Query Response {#response-reqs}
 
-Specifications for each use case MUST each determine how responses to queries for Digital Emblems of their specified type are handled.
-Specifically, they must determine the responsiveness and consistency requirements for emblems of their given type and provide explanations of how the chosen requirements apply and rationales for their selection.
+Specifications for each use case MUST each determine how servers must respond to queries for Digital Emblems of their specified type.
+Specifically, they must determine the responsiveness and consistency requirements for emblems of their given type and
+provide explanations of how the chosen requirements apply and the rationales for their selection.
 
 For responsiveness, an instance of a specific type of digital emblem can either be required to respond to all queries for it (Assured Response), or allowed to selectively respond to a specific subset of incoming queries (Selective Response).
 
-For consistency of response  specifications for a given type of digital emblem must denote whether consistent content is required for all responses provided (Consistent Content) or whether the contents of a response may vary based on specific requester attributes (Selective Content).
+For consistency of response, specifications for a given type of Digital Emblem T must denote whether all queries for an
+asset's records (as denoted by its FQDN) must return all Digital Emblems of type T associated with the
+asset (Consistent Content), or whether the inclusion of emblems of type T in a response may vary based on specific requester attributes (Selective Content).
+
+Note that as of this writing the baseline definition for the minimum set of attributes that constitute a unique Digital
+Emblem, and thus must remain consistent to attain Consistent Content has not been defined.
+Given the limited scope of this document, that definition as well as the mechanism to ensure its extensibility across
+newly defined emblem types will be outlined in the architecture document.
 
 While some use cases may be able to allow selective response and/or selective content, assured response and consistent
 content are  prerequisites for proof of presence.

--- a/draft-ietf-diem-requirements.md
+++ b/draft-ietf-diem-requirements.md
@@ -211,8 +211,8 @@ For consistency of response, specifications for a given type of Digital Emblem T
 asset's records (as denoted by its FQDN) must return all Digital Emblems of type T associated with the
 asset (Consistent Content), or whether the inclusion of emblems of type T in a response may vary based on specific requester attributes (Selective Content).
 
-Note that as of this writing the baseline definition for the minimum set of attributes that constitute a unique Digital
-Emblem, and thus must remain consistent to attain Consistent Content has not been defined.
+Note that as of this writing, neither the baseline definition for the minimum set of attributes that constitute a unique Digital
+Emblem, nor the attributes needed to attain Consistent Content have been defined.
 Given the limited scope of this document, that definition as well as the mechanism to ensure its extensibility across
 newly defined emblem types will be outlined in the architecture document.
 

--- a/draft-ietf-diem-requirements.md
+++ b/draft-ietf-diem-requirements.md
@@ -216,8 +216,6 @@ Emblem, and thus must remain consistent to attain Consistent Content has not bee
 Given the limited scope of this document, that definition as well as the mechanism to ensure its extensibility across
 newly defined emblem types will be outlined in the architecture document.
 
-While some use cases may be able to allow selective response and/or selective content, assured response and consistent
-content are  prerequisites for proof of presence.
 
 ### Removable {#removable}
 


### PR DESCRIPTION
Background: During IETF 125 it was pointed out that many of the digital emblem use cases seemed to assume that all queries for the digital emblem would always get the same response - which was not necessarily consistent with how DNS works. Further discussion about this highlighted that providing a proof of presence not only assumed that all queries would get the same response, but required that this be the case.
 This PR seeks to address that by requiring digital emblem use cases to specifically determine whether they require emblems to support assured response and/or consistent content in all responses and to detail the rationale for their determination. 